### PR TITLE
Improve check for running otelcol process

### DIFF
--- a/install-otelcol-contrib-debian.sh
+++ b/install-otelcol-contrib-debian.sh
@@ -6,12 +6,12 @@
 set -euo pipefail
 
 # Check if any OpenTelemetry Collector process is already running
-if pgrep -f 'otelcol' > /dev/null; then
+if pgrep -f '/otelcol' > /dev/null; then
   echo "An OpenTelemetry Collector process is already running."
   echo "Please stop it before running this installation script."
   echo
   echo "Matching processes:"
-  pgrep -a -f 'otelcol'
+  pgrep -a -f '/otelcol'
   exit 1
 fi
 


### PR DESCRIPTION
Currently, the script detects itself when it tries to detect a running otelcol process:

    $ ./install-otelcol-contrib-debian.sh
    An OpenTelemetry Collector process is already running.
    Please stop it before running this installation script.

    Matching processes:
    92701 /bin/bash ./install-otelcol-contrib-debian.sh

This change is the best I could think of given the filtering possibilities in pgrep; I'd expect any install of otelcontrib to put a binary whose name begins 'otelcol' in a directory somewhere.